### PR TITLE
fix import vue.js

### DIFF
--- a/ui/web/main.html
+++ b/ui/web/main.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">
   <title>procon29</title>
-  <script src="vue.js" defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
   <script src="eel.js" defer></script>
   <script src="script.js" defer></script>
 </head>


### PR DESCRIPTION
main.html(UI表示用)のvue.jsインポートがローカル依存になっていたためクローンしたままだと実行できなかった．そのためjsdeliverから取得するようコードを修正．