### PR TITLE
Server

### DIFF
--- a/control/gameController.py
+++ b/control/gameController.py
@@ -39,8 +39,6 @@ class GameController():
 
         return self.board_cell_scores_np
 
-    # これが実用される
-    # symmetry 0 : 左右対称 1 : 上下対象 2 : 上下左右対称
     def genScores(self, row, column, symmetry):
         column = int(column)
         row = int(row)
@@ -77,7 +75,11 @@ class GameController():
         self.board_cell_scores = scores
         return self.board_cell_scores
 
+    # これが実用される
+    # symmetry 0 : 左右対称 1 : 上下対象 2 : 上下左右対称
     def genScores_py(self, row=12, column=12, symmetry=0):
+        column = int(column)
+        row = int(row)
 
         if symmetry == 0 or symmetry == 2:
             gen_column = column // 2
@@ -100,13 +102,13 @@ class GameController():
                 if random.randint(1, 8) == 8:
                     score = score * (-1)
                 row_scores.append(score)
-            if symmetry == 1 or symmetry == 2:
+            if symmetry == 0 or symmetry == 2:
                 if column % 2:
                     row_scores = row_scores + (row_scores[0:-1])[::-1]
                 else:
                     row_scores = row_scores + row_scores[::-1]
             self.board_cell_scores_py.append(row_scores)
-        if symmetry == 0 or symmetry == 2:
+        if symmetry == 1 or symmetry == 2:
             if row % 2:
                 self.board_cell_scores_py += (self.board_cell_scores_py[0:-1])[::-1]
             else:

--- a/runClient.py
+++ b/runClient.py
@@ -1,5 +1,4 @@
 import sys
-import os
 import numpy as np
 from ui.webUi import WebUi
 from control.gameController import GameController
@@ -21,10 +20,10 @@ class UiPanel(object):
         print(self.webUi.getCellScore(board_row, board_column))
         self.webUi.editCellAttrs(board_row, board_column, "a-area", True)
 
-    def gameStart(self, board_row, board_column):
+    def gameStart(self, board_row, board_column, symmetry_id=0):
         # 本当はboard_cell_scoresはサーバープロセスから渡される
         controller = GameController()
-        board_cell_scores = controller.genScores(board_row, board_column, 1)
+        board_cell_scores = controller.genScores_py(board_row, board_column, symmetry_id)
         # -------------------------------------------------------------------
         print(board_cell_scores)
         self.webUi.showBoard(board_cell_scores.tolist())

--- a/ui/callUi_example.py
+++ b/ui/callUi_example.py
@@ -1,6 +1,4 @@
 import sys
-import os
-from PyQt5.Qt import *
 import numpy as np
 np.set_printoptions(threshold=np.inf)
 from main_ui import Ui_Dialog

--- a/ui/web/script.js
+++ b/ui/web/script.js
@@ -11,12 +11,25 @@ const app = new Vue({
     },
     options: {
       row: 12,
-      column: 12
+      column: 12,
+      symmetry_v: false,
+      symmetry_h: true
     }
   },
   methods: {
     gameStart: function() {
-      eel.gameStart(this.options.row, this.options.column);
+      let symmetry_id = 0;
+      if(this.options.symmetry_v && this.options.symmetry_h){
+        symmetry_id = 2
+      }else if(this.options.symmetry_v){
+        symmetry_id = 1
+      }else if(this.options.symmetry_h){
+        symmetry_id = 0
+      }else{
+        alert("対称設定が行われていません");
+        exit();
+      }
+      eel.gameStart(this.options.row, this.options.column, symmetry_id);
     },
 
     show: function(preparedCellScores) {

--- a/ui/webUi.py
+++ b/ui/webUi.py
@@ -1,7 +1,4 @@
-import signal
-import sys
 import eel
-import socket
 
 
 class WebUi:
@@ -15,9 +12,9 @@ class WebUi:
                 self.events["cellClicked"](row, column)
 
         @eel.expose
-        def gameStart(row, column):
+        def gameStart(row, column, symmetry_id):
             if "gameStart" in self.events:
-                self.events["gameStart"](row, column)
+                self.events["gameStart"](row, column, symmetry_id)
 
     def addEvent(self, event_name: str, func: object):
         self.events[event_name] = func


### PR DESCRIPTION
点対称しか生成しなかったgenscore_py()の引数にsymmetry: intを追加．
0:上下対称 1:左右対象 3:上下左右対称(点対称)で生成する盤面を変更できる．
genscore_py(row, ccolumn, symmetry)

伴ってUIに対称設定用のチェックボックスを追加．対称設定がされていないとアラートを表示．